### PR TITLE
Validate test runner args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,15 @@ for lib in $libs; do awk -f bashdoc-to-md.awk $lib > $lib.md ; done
 
 ## BUILDS / PKGS
 
-Currently these run tests against the bash functions.
+Shippable will react to the push of a git tag event by building, testing and
+on success creating a release for that tag.
 
-TODO:
+Additionally, .tgz bundles are created as release attachments. Each bundle
+contains the assets needed to easily automate particular tasks
+in a consistent and predictable manner e.g for running terraform, or
+another bundle for building an AMI.
 
-On a git tag push event, create bundles of related scripts and upload
-as binary assets to a github release. e.g. all utility scripts for running terraform,
-or building an AMI _opsgang_ style.
-
-These could then be retrieved with [opsgang/fetch][1].
+Bundles can be retrieved easily using [opsgang/fetch][1].
 
 ## TESTS
 

--- a/bash/t/habitual/git.functions
+++ b/bash/t/habitual/git.functions
@@ -10,7 +10,7 @@ _EMAIL="boo@boo.com"
 HEAD_SHA="set-in-setup()"
 SECOND_SHA="set-in-setup()"
 
-setup() {
+pre_run() {
     i "... setting up for tests"
     if [[ -z "$TESTS_DEVMODE" ]]; then
         rm -rf $L_REPO $L_NONREPO 2>/dev/null
@@ -393,7 +393,7 @@ t_error_checking_if_not_a_git_dir() {
 
 ! . t/t.functions && echo "ERROR $0: could not source t.functions" && exit 1
 source_src_and_deps "habitual/std.functions" || exit 1
-setup || exit 1
+pre_run || exit 1
 
 run $*
 

--- a/bash/t/t.functions
+++ b/bash/t/t.functions
@@ -1,7 +1,46 @@
 # vim: et sr sw=4 ts=4 smartindent syntax=sh:
+#
+# t/t.functions
+#
+
+# $FAILURES:
+# ... used to capture failed test names.
 FAILURES=""
-SRC="${0##\./}"
-SRC="${SRC##t/}"
+
+# $SRC:
+# ... relative path to actual lib file to test
+#     determined by set_SRC(), called when you source
+#     t/t.functions.
+SRC=
+
+# tests must be run from within the ./bash dir and the test script
+# name should be set using a relative path
+set_SRC() {
+    if ! command -v realpath >/dev/null 2>&1
+    then
+        echo "ERROR: you must install GNU tools like realpath" >&2
+        echo "ERROR: before using opsgang/libs." >&2
+        exit 1
+    fi
+
+    if [[ ! $(pwd) =~ /bash$ ]]; then
+        echo "ERROR: you must call test script from inside the bash dir" >&2
+        exit 1
+    fi
+
+    SRC="$(realpath -- $0 | sed -e 's!.\+/bash/t/!!')"
+    SRC="$SRC"
+    if [[ $? -ne 0 ]]; then
+        echo "ERROR: problems determining real path to $0" >&2
+        exit 1
+    fi
+
+    if [[ ! -r $SRC ]]; then
+        echo "ERROR: can not find the lib $SRC for test script $0" >&2
+        exit 1
+    fi
+
+}
 
 run_t() {
     local func="${1#t_}"
@@ -66,3 +105,5 @@ results() {
         return 1
     fi
 }
+
+set_SRC || return 1


### PR DESCRIPTION
Improved the function that makes sure we are calling the test script correctly.

Now also checks that realpath is installed, and that the corresponding lib file is readable.