### PR TITLE
NO_APPLY option for terraform_run ; std::run_if_exists()

### DIFF
--- a/bash/habitual/std.functions
+++ b/bash/habitual/std.functions
@@ -44,10 +44,39 @@ source_files() {
     return $rc
 }
 
-# @desc Checks a list of vars for undefined
-# or empty vals. 
+# @desc Run function if it exists.
 #
-# **Whitespace and _0_ are considered values.**
+# Pass name of function (and then optionally any params for function)
+#
+# Executes function *IF it exists*.
+#
+# Success if function executes correctly or does not exist.
+#
+# @example
+#   # ... run my_func() if exists, with args 'apple', 'banana'
+#   std::run_if_exists "my_func" apple banana
+#
+#   # ... run my_func() if exists, with arg containing spaces
+#   std::run_if_exists "my_func" "This whole sentence is arg1."
+#
+std::run_if_exists() {
+    local f="$1"
+    [[ -z "$f" ]] && red_e "... expects function name as 1st arg." && return 1
+
+    if declare -f "$f" >/dev/null 2>&1
+    then
+        d "... running '$f' function" && $f "${@:2}"
+        return $?
+    else
+        d "... function '$f()' not found"
+        return 0
+    fi
+}
+
+# @desc Checks a list of vars for undefined
+# or empty vals.
+#
+# **Whitespace or _0_ is not considered empty.**
 #
 # Returns 1 if any are undefined or empty.
 #
@@ -58,7 +87,7 @@ source_files() {
 required_vars() {
     local rc=0
     local required_vars="$1"
-    local this_var
+    local this_var=""
     for this_var in $required_vars; do
         if ! check_var_defined $this_var
         then
@@ -72,7 +101,7 @@ required_vars() {
 
 # @desc Checks if a var has an empty value.
 #
-# **Whitespace and _0_ are considered non-empty values.**
+# **Whitespace or _0_ is not considered empty.**
 #
 # Returns 1 if undefined / empty.
 #
@@ -80,15 +109,7 @@ required_vars() {
 #   # ... test to see $FOO and $BAR are non-empty.
 #   check_var_defined "FOO" || echo "FOO is empty or not defined"
 #
-check_var_defined() {
-    local var_name="$1"
-    local var_val="${!var_name}"
-    if [[ -z $var_val ]]; then
-        return 1
-    else
-        return 0
-    fi
-}
+check_var_defined() { [[ ! -z "${!1}" ]] ; }
 
 # @desc Prints a user-passed *single-line* str with all instances of certain chars
 # replaced by a safe character.
@@ -106,14 +127,14 @@ check_var_defined() {
 #
 # > To use `]` and/or `[` in Arg 2, they must appear at start of pattern in that order
 # > (after any leading `!` if you want to specify a disallowed list)
-# > 
+# >
 # > To use `-` in Arg2, it MUST appear as the last char.
 # > You can use named POSIX character classes e.g. [:blank:] or [:alnum:].
 #
 # * Arg 3: Optional: the list of chars to keep (*or replace if prefixed with* `!`)
 #
 # > To include a literal `!` in a list to replace, add another exclamation mark.
-# > 
+# >
 # > The default is strict, replacing all but alphanumerics and these chars:`_.:/=+-@`
 #
 # Call [safe_chars_def_list](#safe_chars_def_list) to get the default char list.
@@ -275,7 +296,7 @@ _semver_a_gt_b() {
 #
 # $BUILD_URL is a link to a CI/CD job's run.
 #
-# Returns 1 if BUILD_URL can not be determined. 
+# Returns 1 if BUILD_URL can not be determined.
 #
 # Use this to annotate your builds and deployments with governance metadata. e.g. the job run
 # should show you who built what when.
@@ -292,7 +313,7 @@ export_build_url() {
     elif [[ "$TRAVIS" == "true" ]]; then
         if required_vars "TRAVIS_REPO_SLUG TRAVIS_JOB_ID"
         then
-            BUILD_URL="https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID" 
+            BUILD_URL="https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID"
         fi
     fi
     [[ ! -z "$BUILD_URL" ]] && export BUILD_URL

--- a/bash/habitual/std.functions
+++ b/bash/habitual/std.functions
@@ -111,6 +111,21 @@ required_vars() {
 #
 check_var_defined() { [[ ! -z "${!1}" ]] ; }
 
+# @desc Trim leading and trailing whitespace from a string
+#
+# @example
+#   std::trim_str " <- spaces disappear! ->  "
+#   # ^^^ outputs "<- spaces disappear! ->"
+#
+std::trim_str() {
+    local v="$*"
+    # ... remove leading
+    v="${v#"${v%%[![:space:]]*}"}"
+    # ... remove trailing
+    v="${v%"${v##*[![:space:]]}"}"
+    echo -n "$v"
+}
+
 # @desc Prints a user-passed *single-line* str with all instances of certain chars
 # replaced by a safe character.
 #

--- a/bash/habitual/std.functions.md
+++ b/bash/habitual/std.functions.md
@@ -29,6 +29,7 @@
 ## MISC. FUNCTIONS
 ---
 * [source\_files()](#source_files)
+* [std::run\_if\_exists()](#stdrun_if_exists)
 * [required\_vars()](#required_vars)
 * [check\_var\_defined()](#check_var_defined)
 * [str\_to\_safe\_chars()](#str_to_safe_chars)
@@ -76,12 +77,36 @@ IGNORE_MISSING=true source_files "default.cfg env.cfg project.cfg"
 
 ---
 
+### std::run\_if\_exists()
+
+Run function if it exists.
+
+Pass name of function (and then optionally any params for function)
+
+Executes function *IF it exists*.
+
+Success if function executes correctly or does not exist.
+
+#### Example
+
+```bash
+# ... run my_func() if exists, with args 'apple', 'banana'
+std::run_if_exists "my_func" apple banana
+
+# ... run my_func() if exists, with arg containing spaces
+std::run_if_exists "my_func" "This whole sentence is arg1."
+
+```
+
+
+---
+
 ### required\_vars()
 
 Checks a list of vars for undefined
-or empty vals. 
+or empty vals.
 
-**Whitespace and _0_ are considered values.**
+**Whitespace or _0_ is not considered empty.**
 
 Returns 1 if any are undefined or empty.
 
@@ -100,7 +125,7 @@ required_vars "FOO BAR" || exit 1
 
 Checks if a var has an empty value.
 
-**Whitespace and _0_ are considered non-empty values.**
+**Whitespace or _0_ is not considered empty.**
 
 Returns 1 if undefined / empty.
 
@@ -133,14 +158,14 @@ Or to create valid AWS tag values (there is a limited set of valid chars)
 
 > To use `]` and/or `[` in Arg 2, they must appear at start of pattern in that order
 > (after any leading `!` if you want to specify a disallowed list)
-> 
+>
 > To use `-` in Arg2, it MUST appear as the last char.
 > You can use named POSIX character classes e.g. [:blank:] or [:alnum:].
 
 * Arg 3: Optional: the list of chars to keep (*or replace if prefixed with* `!`)
 
 > To include a literal `!` in a list to replace, add another exclamation mark.
-> 
+>
 > The default is strict, replacing all but alphanumerics and these chars:`_.:/=+-@`
 
 Call [safe_chars_def_list](#safe_chars_def_list) to get the default char list.
@@ -250,7 +275,7 @@ Exports $BUILD_URL if available from a number of possible sources.
 
 $BUILD_URL is a link to a CI/CD job's run.
 
-Returns 1 if BUILD_URL can not be determined. 
+Returns 1 if BUILD_URL can not be determined.
 
 Use this to annotate your builds and deployments with governance metadata. e.g. the job run
 should show you who built what when.

--- a/bash/habitual/std.functions.md
+++ b/bash/habitual/std.functions.md
@@ -32,6 +32,7 @@
 * [std::run\_if\_exists()](#stdrun_if_exists)
 * [required\_vars()](#required_vars)
 * [check\_var\_defined()](#check_var_defined)
+* [std::trim\_str()](#stdtrim_str)
 * [str\_to\_safe\_chars()](#str_to_safe_chars)
 * [safe\_chars\_def\_list()](#safe_chars_def_list)
 * [envsubst\_tokens\_list()](#envsubst_tokens_list)
@@ -134,6 +135,21 @@ Returns 1 if undefined / empty.
 ```bash
 # ... test to see $FOO and $BAR are non-empty.
 check_var_defined "FOO" || echo "FOO is empty or not defined"
+
+```
+
+
+---
+
+### std::trim\_str()
+
+Trim leading and trailing whitespace from a string
+
+#### Example
+
+```bash
+std::trim_str " <- spaces disappear! ->  "
+# ^^^ outputs "<- spaces disappear! ->"
 
 ```
 

--- a/bash/t/habitual/std.functions
+++ b/bash/t/habitual/std.functions
@@ -46,7 +46,7 @@ t_source_files() {
     run_t t_fail_if_file_bad_syntax
     run_t t_fail_if_file_does_not_exist
     run_t t_succeed_if_missing_file_with_ignore
-    run_t t_fail_if_file_exists_with_ignore
+    run_t t_fail_if_file_bad_syntax_with_ignore
 }
 
 ### std::run_if_exists()
@@ -57,6 +57,8 @@ t_std::run_if_exists() {
     run_t t_func_does_not_exist
     run_t t_func_name_not_passed
     run_t t_invalid_func_name
+    run_t t_called_func_success
+    run_t t_called_func_error
 }
 
 ### check_var_defined
@@ -65,6 +67,42 @@ t_check_var_defined() {
     run_t t_non_empty_var_is_success
     run_t t_unset_var_is_error
     run_t t_empty_var_is_error
+}
+
+### std::trim_str()
+t_std::trim_str() {
+    SUITE="${FUNCNAME[0]#t_}()"
+    run_t t_leading_whitespace_removed
+    run_t t_trailing_whitespace_removed
+    run_t t_no_whitespace_unchanged
+    run_t t_whitespace_tabs
+    run_t t_whitespace_newlines
+}
+
+t_leading_whitespace_removed() {
+    local str="  leading spaces"
+    [[ $(std::trim_str "$str") == "leading spaces" ]]
+}
+
+t_trailing_whitespace_removed() {
+    local str="no removed whitespace"
+    [[ $(std::trim_str "$str") == "no removed whitespace" ]]
+}
+
+t_no_whitespace_unchanged() {
+    local str="trailing spaces    "
+    [[ $(std::trim_str "$str") == "trailing spaces" ]]
+}
+
+# ... tabs should be removed
+t_whitespace_tabs() {
+    local str="$(echo -e " \t remove leading tab too")"
+    [[ $(std::trim_str "$str") == "remove leading tab too" ]]
+}
+
+t_whitespace_newlines() {
+    local str="$(echo -e " \n remove leading newline too")"
+    [[ $(std::trim_str "$str") == "remove leading newline too" ]]
 }
 
 ### required_vars()

--- a/bash/t/habitual/std.functions
+++ b/bash/t/habitual/std.functions
@@ -49,6 +49,16 @@ t_source_files() {
     run_t t_fail_if_file_exists_with_ignore
 }
 
+### std::run_if_exists()
+t_std::run_if_exists() {
+    SUITE="${FUNCNAME[0]#t_}()"
+    run_t t_func_exists_no_args
+    run_t t_func_exists_args
+    run_t t_func_does_not_exist
+    run_t t_func_name_not_passed
+    run_t t_invalid_func_name
+}
+
 ### check_var_defined
 t_check_var_defined() {
     SUITE="${FUNCNAME[0]#t_}()"
@@ -339,6 +349,76 @@ t_fail_if_file_bad_syntax_with_ignore() {
     ! IGNORE_MISSING=true source_files $f.1 $f.2 $f.3 >/dev/null 2>&1 || rc=1
     rm $f.1 $f.2 $f.3
     return $rc
+}
+
+
+t_func_exists_no_args() {
+    (
+        local o="" foo=""
+        foo() { echo "$@" ; }
+        o=$(DEBUG=true std::run_if_exists foo 2>&1)
+        [[ $? -ne 0 ]] && exit 1
+        echo "$o" | grep &>/dev/null "running 'foo' function" || exit 1
+    )
+}
+
+t_func_exists_args() {
+    (
+        local o="" foo=""
+        foo() { echo "foo says: $@" ; }
+        o=$(DEBUG=true std::run_if_exists foo arg1 arg2 2>&1)
+        [[ $? -ne 0 ]] && exit 1
+        echo "$o" | grep &>/dev/null 'foo says: arg1 arg2' || exit 1
+    )
+}
+
+t_func_does_not_exist() {
+    (
+        local o=""; unset foo
+        o=$(DEBUG=true std::run_if_exists foo 2>&1)
+        [[ $? -ne 0 ]] && exit 1 # should return success
+        echo "$o" | grep &>/dev/null "function 'foo()' not found" || exit 1
+    )
+}
+
+t_func_name_not_passed() {
+    (
+        local o=""
+        o=$(std::run_if_exists 2>&1)
+        [[ $? -eq 0 ]] && exit 1 # should fail, as arg not passed
+        echo "$o" | grep &>/dev/null 'expects function name as 1st arg' || exit 1
+    )
+}
+
+t_invalid_func_name() {
+    (
+        local o=""
+        o=$(DEBUG=true std::run_if_exists "; foo" 2>&1)
+        [[ $? -eq 0 ]] || exit 1 # should fail, as arg not passed
+        echo "$o" | grep &>/dev/null "function '; foo()' not found" || exit 1
+    )
+}
+
+t_called_func_success() {
+    (
+        local o="" foo="" rc=""
+        foo() { echo "ran foo" ; }
+        o=$(std::run_if_exists foo 2>&1)
+        rc=$?
+        echo "$o" | grep &>/dev/null 'ran foo' || exit 1
+        [[ $rc -eq 0 ]] || exit 1 # foo() should return 0
+    )
+}
+
+t_called_func_error() {
+    (
+        local o="" foo="" rc=""
+        foo() { echo "ran foo" ; return 212 ; }
+        o=$(std::run_if_exists foo 2>&1)
+        rc=$?
+        echo "$o" | grep &>/dev/null 'ran foo' || exit 1
+        [[ $rc -eq 212 ]] || exit 1 # foo() should return 212
+    )
 }
 
 ### Tests for logging functions

--- a/bash/t/terraform/terraform_run.functions
+++ b/bash/t/terraform/terraform_run.functions
@@ -30,9 +30,9 @@ setup_terraform_stubs() {
     local trc="${2:-0}" # terraform return code
     TERRAFORM=terraform # use the stub declared in this setup
 
-    stub_terraform_version="$(echo -e "terraform_version() {\necho $v\n}")"
+    stub_terraform_version="terraform_version() { echo $v ; }"
 
-    stub_terraform=$(echo -e "terraform(){\necho \$*; return $trc\n}")
+    stub_terraform="terraform(){ echo \$* ; return $trc ; }"
 
     eval "$stub_terraform_version"
     eval "$stub_terraform"
@@ -46,7 +46,7 @@ setup_terraform_run_stubs() {
 
     setup_terraform_stubs "$v" $trc
 
-    stub_no_unpushed_changes="$(echo -e "no_unpushed_changes() {\nreturn $nrc\n}")"
+    stub_no_unpushed_changes="no_unpushed_changes() { return $nrc ; }"
     eval "$stub_no_unpushed_changes"
 
     for hook in $__HOOKS; do

--- a/bash/t/terraform/terraform_run.functions
+++ b/bash/t/terraform/terraform_run.functions
@@ -1,6 +1,6 @@
 #!/bin/bash
 # vim: et sr sw=4 ts=4 smartindent syntax=sh:
-# TESTS terraform
+# TESTS terraform functions.
 #
 
 __CLEANUP_DIR="/var/tmp/functions.terraform.cleanup"
@@ -137,12 +137,14 @@ t_terraform_apply() {
     run_t t_apply_lt_0_11_with_opts
     run_t t_apply_ge_0_11_with_opts
     run_t t_apply_skip_if_devmode
+    run_t t_apply_skip_if_no_apply
 }
 
 ### terraform_run
 t_terraform_run() {
     SUITE="${FUNCNAME[0]#t_}()"
     run_t t_run_in_devmode_skipping
+    run_t t_run_in_no_apply_skipping
     run_t t_run_full_lifecycle
     run_t t_run_fail_if_bad_working_dir
 }
@@ -164,12 +166,10 @@ t_fails_if_custom_governance_vars_does() {
     local rc=0
     rm -rf $d 2>/dev/null ; mkdir -p $d
     (
-        cd $d
-        tf_custom_governance_vars() {
-            return 1
-        }
+        cd $d ; local msg="RAN tf_custom_governance_vars()"
+        tf_custom_governance_vars() { echo "$msg" ; return 1; }
         o=$(tf_export_governance_vars 2>&1)
-        [[ $? -ne 0 ]] && echo "$o" | grep '... failed' >/dev/null
+        [[ $? -ne 0 ]] && echo "$o" | grep "$msg" >/dev/null
     ) || rc=1
     rm -rf $d 2>/dev/null ; return $rc
 }
@@ -196,6 +196,15 @@ t_run_in_devmode_skipping() {
         setup_terraform_stubs 0.8.8
         o=$(DEVMODE=true terraform_run 2>&1) || return 1
         echo "$o" | grep 'skipping git checks' >/dev/null || return 1
+        echo "$o" | grep 'skipping terraform apply' >/dev/null || return 1
+    )
+}
+
+t_run_in_no_apply_skipping() {
+    (
+        set -o pipefail
+        setup_terraform_run_stubs 0.8.8
+        o=$(NO_APPLY=true terraform_run 2>&1) || return 1
         echo "$o" | grep 'skipping terraform apply' >/dev/null || return 1
     )
 }
@@ -265,8 +274,16 @@ t_apply_skip_if_devmode() {
     (
         set -o pipefail
         setup_terraform_stubs 0.11.0
-        DEVMODE=true
-        o=$(terraform_apply 2>&1)
+        o=$(DEVMODE=true terraform_apply 2>&1)
+        [[ $? -eq 0 ]] && [[ $(echo "$o" | tail -n 1) =~ skipping\ terraform\ apply ]]
+    )
+}
+
+t_apply_skip_if_no_apply() {
+    (
+        set -o pipefail
+        setup_terraform_stubs 0.11.0
+        o=$(NO_APPLY=true terraform_apply 2>&1)
         [[ $? -eq 0 ]] && [[ $(echo "$o" | tail -n 1) =~ skipping\ terraform\ apply ]]
     )
 }

--- a/bash/terraform/terraform_run.functions
+++ b/bash/terraform/terraform_run.functions
@@ -241,11 +241,11 @@ terraform_init() {
 
 # @desc Runs `terraform apply` - for v0.11.0+, will add the -auto-approve to run it non-interactively.
 #
-# Some [globals](#globals) - $TERRAFORM, $TERRAFORM_APPLY_OPTS, $DEVMODE - affect behaviour.
+# [Globals](#globals) - $TERRAFORM, $TERRAFORM_APPLY_OPTS, $DEVMODE, NO_APPLY - affect behaviour.
 #
 # Set $TERRAFORM_APPLY_OPTS to pass `apply` any other options.
 #
-# When $DEVMODE is set, `apply` is not actually run.
+# When $DEVMODE or $NO_APPLY is set, `apply` is not actually run.
 #
 terraform_apply() {
     i "... applying terraform"
@@ -315,9 +315,11 @@ __skip_on() {
 #
 # ##### lifecycle hooks
 #
-# > **CAVEAT** - if you are using any hooks to modify your actual infrastructure,
-# > make them no-op if in $DEVMODE , as `terraform apply` will not run.
-# > See terraform_postapply example below.
+# > **CAVEAT** - if you are using any hooks **to modify your actual infrastructure**,
+# > make them check for $DEVMODE (and possibly $NO_APPLY, depending on your needs)
+# > and do nothing!
+# >
+# > See terraform_postapply example below for this kind of check.
 # >
 # > For custom governance vars see [tf_export_governance_vars](#tf_export_governance_vars).
 #
@@ -354,7 +356,7 @@ __skip_on() {
 #
 #       # example: postapply func used to switch dns to route traffic from 'blue' to 'green' stack
 #       terraform_postapply() {
-#           [[ -n "$DEVMODE" ]] && i "DEVMODE, so no-op." && return 0
+#           [[ -n "${DEVMODE}${NO_APPLY}" ]] && i "not applying terraform, so no-op." && return 0
 #           stack=$(which_stack_is_not_live)
 #           set_dns "live-$stack.example.com" || return 1
 #       }

--- a/bash/terraform/terraform_run.functions
+++ b/bash/terraform/terraform_run.functions
@@ -34,15 +34,8 @@ KEEP_PLUGINS="${KEEP_PLUGINS:-}"
 # ... set to non-empty value to skip git checks and `terraform apply`
 DEVMODE="${DEVMODE:-}"
 
-__run_if_exists() {
-    local f="$1"
-    if declare -f $f >/dev/null 2>&1
-    then
-        d "... running $f function"
-        ! $f && e "... failed." &&  return 1
-    fi
-    return 0
-}
+# ... don't perform terraform-apply
+NO_APPLY="${NO_APPLY:-}"
 
 __show_env() {
     [[ -z "$DEVMODE" ]] && return 0
@@ -110,7 +103,7 @@ tf_export_governance_vars() {
     export TF_VAR_git_user="$GIT_USER"
     export TF_VAR_git_info="$GIT_INFO"
     export TF_VAR_build_url="$BUILD_URL"
-    __run_if_exists tf_custom_governance_vars || return 1
+    std::run_if_exists tf_custom_governance_vars || return 1
 }
 
 # @desc Returns the path to the terraform binary.
@@ -144,6 +137,7 @@ terraform_version() {
 __special_modes() {
     _disclaimer_devmode
     _disclaimer_keep_plugins
+    _disclaimer_no_apply
 }
 
 _disclaimer_devmode() {
@@ -167,6 +161,17 @@ _disclaimer_keep_plugins() {
         yellow_i "================================================="
         bold_i   "... will not delete previously downloaded"
         bold_i   "    terraform plugins."
+        yellow_i "================================================="
+    fi
+}
+
+_disclaimer_no_apply() {
+    local v='NO_APPLY'
+    if [[ ! -z "${!v}" ]] ; then
+        yellow_i "================================================="
+        yellow_i "= ACTIVATED: \$${v}"
+        yellow_i "================================================="
+        bold_i   "... will not run terraform apply"
         yellow_i "================================================="
     fi
 }
@@ -256,8 +261,27 @@ terraform_apply() {
         yellow_i "$opts"
         yellow_i "================================================="
     fi
-    [[ ! -z "$DEVMODE" ]] && yellow_i "DEVMODE - skipping terraform apply" && return 0
+    __skip_on "DEVMODE NO_APPLY" "terraform apply" && return 0
+
     eval "$TERRAFORM apply $opts"
+}
+
+__skip_on() {
+    local flags="$1" # ... we should skip if any of this list of vars is set
+    local msg="$2"   # ... info msg to print on skip
+    local var_name=""
+    local rc=1
+
+    for var_name in $flags; do
+        if [[ ! -z "${!var_name}" ]]; then
+            d "... env var \$$var_name set."
+            rc=0
+        fi
+    done
+
+    [[ $rc -eq 0 ]] && yellow_i "... skipping $msg"
+
+    return $rc
 }
 
 # @desc Wrapper cmd to perform terraform subcommands for `init` (or `remote cfg`/`get`), `plan`, `apply`.
@@ -355,13 +379,13 @@ terraform_run() {
 
         terraform_cleanup || exit 1
 
-        __run_if_exists terraform_preinit  || exit 1
+        std::run_if_exists terraform_preinit  || exit 1
 
         tf_export_governance_vars || exit 1
 
         terraform_init || exit 1
 
-        __run_if_exists terraform_postinit  || exit 1
+        std::run_if_exists terraform_postinit  || exit 1
 
         __show_env # if DEVMODE, will print out exported vars.
 
@@ -369,11 +393,11 @@ terraform_run() {
 
         no_unpushed_changes || exit 1
 
-        __run_if_exists terraform_preapply  || exit 1
+        std::run_if_exists terraform_preapply  || exit 1
 
         terraform_apply || exit 1
 
-        __run_if_exists terraform_postapply  || exit 1
+        std::run_if_exists terraform_postapply  || exit 1
 
     ) || return 1
 

--- a/bash/terraform/terraform_run.functions.md
+++ b/bash/terraform/terraform_run.functions.md
@@ -169,11 +169,11 @@ Some [globals](#globals) - $TERRAFORM, $TERRAFORM_INIT_OPTS, TERRAFORM_GET_OPTS 
 
 Runs `terraform apply` - for v0.11.0+, will add the -auto-approve to run it non-interactively.
 
-Some [globals](#globals) - $TERRAFORM, $TERRAFORM_APPLY_OPTS, $DEVMODE - affect behaviour.
+[Globals](#globals) - $TERRAFORM, $TERRAFORM_APPLY_OPTS, $DEVMODE, NO_APPLY - affect behaviour.
 
 Set $TERRAFORM_APPLY_OPTS to pass `apply` any other options.
 
-When $DEVMODE is set, `apply` is not actually run.
+When $DEVMODE or $NO_APPLY is set, `apply` is not actually run.
 
 
 ---
@@ -211,9 +211,11 @@ changes, and also to ensure that the git audit info is accurate.
 
 ##### lifecycle hooks
 
-> **CAVEAT** - if you are using any hooks to modify your actual infrastructure,
-> make them no-op if in $DEVMODE , as `terraform apply` will not run.
-> See terraform_postapply example below.
+> **CAVEAT** - if you are using any hooks **to modify your actual infrastructure**,
+> make them check for $DEVMODE (and possibly $NO_APPLY, depending on your needs)
+> and do nothing!
+>
+> See terraform_postapply example below for this kind of check.
 >
 > For custom governance vars see [tf_export_governance_vars](#tf_export_governance_vars).
 
@@ -252,7 +254,7 @@ changes, and also to ensure that the git audit info is accurate.
 
     # example: postapply func used to switch dns to route traffic from 'blue' to 'green' stack
     terraform_postapply() {
-        [[ -n "$DEVMODE" ]] && i "DEVMODE, so no-op." && return 0
+        [[ -n "${DEVMODE}${NO_APPLY}" ]] && i "not applying terraform, so no-op." && return 0
         stack=$(which_stack_is_not_live)
         set_dns "live-$stack.example.com" || return 1
     }

--- a/bash/terraform/terraform_run.functions.md
+++ b/bash/terraform/terraform_run.functions.md
@@ -45,6 +45,10 @@
     * reads env var `$DEVMODE`
     * or default val: `empty string`
 
+* `$NO_APPLY`: _... don't perform terraform-apply_
+    * reads env var `$NO_APPLY`
+    * or default val: `empty string`
+
 
 
 # FUNCTIONS


### PR DESCRIPTION
* user can set env var NO_APPLY which prevents terraform from
    running its `apply` stage. Useful for when you want to
    only see the plan, and validate there are no unpushed changes.

* terraform __run_if_exists() function moved to public function
    `std::run_if_exists()`.

* relevant tests and docs updated.