### PR TITLE
DEBUG_ABS_PATHS introduced

### DIFF
--- a/bash/bashdoc-to-md.awk
+++ b/bash/bashdoc-to-md.awk
@@ -104,10 +104,10 @@ function strip_md(text) {
     }
 
     if (var_comment) {
-        vardoc = vardoc "\n* `\$" varname "`: _" var_comment "_\n" defaults
+        vardoc = vardoc "\n* `$" varname "`: _" var_comment "_\n" defaults
     }
     else {
-        vardoc = vardoc "\n* `\$" varname "`\n" defaults
+        vardoc = vardoc "\n* `$" varname "`\n" defaults
     }
 
 

--- a/bash/habitual/std.functions
+++ b/bash/habitual/std.functions
@@ -370,6 +370,9 @@ __CALLER_REGX="^([^ ]+) ([^ ]+) (.+)$"
 # ... set in env to non-empty value to print debug messages to STDERR (See [d()](#d))
 DEBUG=${DEBUG:-}
 
+# ... set in env to use abs paths to source files in any messages. (See [d()](#d))
+DEBUG_ABS_PATHS=${DEBUG_ABS_PATHS:-}
+
 # ... set in env to non-empty value to silence all messages apart from errors
 QUIET=${QUIET:-}
 
@@ -394,7 +397,7 @@ set_log_prefix() {
 
         # ... if the cwd is changed, realpath may not work, so fall back to just $src
         f=$(realpath -- "$src" 2>/dev/null); [[ -z "$f" ]] && f=$src
-        if [[ ! -z "$DEBUG" ]]; then
+        if [[ ! -z "$DEBUG_ABS_PATHS" ]]; then
             str=$f
         else
             str=$(basename "$f")
@@ -465,6 +468,13 @@ i() {
 # Caller can pass multiple quoted strings as each line
 # of the msg.
 # _\n_ within a str is also treated as newline.
+#
+# Set DEBUG in env to turn on msgs at this level.
+#
+# Set DEBUG_ABS_PATHS in env to have abs paths to the source
+# file in each DEBUG msgs.
+#
+# Set QUIET in the env to ignore DEBUG settings.
 #
 # @example
 #   d "msg line 1" "line 2\nline3"

--- a/bash/habitual/std.functions.md
+++ b/bash/habitual/std.functions.md
@@ -18,6 +18,10 @@
     * reads env var `$DEBUG`
     * or default val: `empty string`
 
+* `$DEBUG_ABS_PATHS`: _... set in env to use abs paths to source files in any messages. (See [d()](#d))_
+    * reads env var `$DEBUG_ABS_PATHS`
+    * or default val: `empty string`
+
 * `$QUIET`: _... set in env to non-empty value to silence all messages apart from errors_
     * reads env var `$QUIET`
     * or default val: `empty string`
@@ -368,6 +372,13 @@ prints DEBUG msg (STDERR) with context prefix.
 Caller can pass multiple quoted strings as each line
 of the msg.
 _\n_ within a str is also treated as newline.
+
+Set DEBUG in env to turn on msgs at this level.
+
+Set DEBUG_ABS_PATHS in env to have abs paths to the source
+file in each DEBUG msgs.
+
+Set QUIET in the env to ignore DEBUG settings.
 
 #### Example
 

--- a/bash/t/habitual/std.functions
+++ b/bash/t/habitual/std.functions
@@ -5,7 +5,8 @@
 
 # ... for logging functions 
 EXPECTED_PREFIX="$(basename $0)"
-EXPECTED_DEBUG_PREFIX="$(realpath -- $0)" # horrid, but no better way
+EXPECTED_DEBUG_PREFIX="$(basename -- $0)"
+EXPECTED_ABS_PATHS_PREFIX="$(realpath -- $0)" # horrid, but no better way
 
 # ... for str_to_safe_chars()
 STR_ASCII="$(for((i=32;i<=127;i++)) do printf \\$(printf '%03o\t' "$i"); done;printf "\n")@"
@@ -487,6 +488,7 @@ t_set_log_prefix() {
     run_t t_prefix_when_run_from_script_with_debug
     run_t t_prefix_when_run_in_subshell
     run_t t_prefix_when_run_in_sourced_file
+    run_t t_prefix_debug_abs_paths_set
 }
 
 ### d()
@@ -495,12 +497,14 @@ t_d() {
     run_t t_no_output_if_DEBUG_not_set
     run_t t_output_if_debug_set
     run_t t_no_debug_output_if_QUIET
+    run_t t_d_abs_paths_set
 }
 
 ### i()
 t_i() {
     SUITE="${FUNCNAME[0]#t_}()"
     run_t t_no_i_output_if_QUIET
+    run_t t_i_abs_paths_set
 }
 
 ### __stacktrace()
@@ -521,8 +525,18 @@ t_no_debug_output_if_QUIET() {
     [[ "$(QUIET=true DEBUG=true d 'should print nothing' 2>&1)" == "" ]]
 }
 
+t_d_abs_paths_set() {
+    echo "$(DEBUG=true DEBUG_ABS_PATHS=true d 'should print' 2>&1)" \
+    | grep -Po "^DEBUG $EXPECTED_ABS_PATHS_PREFIX:.*should print" >/dev/null
+}
+
 t_no_i_output_if_QUIET() {
     [[ "$(QUIET=true i 'should print nothing' 2>&1)" == "" ]]
+}
+
+t_i_abs_paths_set() {
+    echo "$(DEBUG_ABS_PATHS=true i 'should print' 2>&1)" \
+    | grep -Po "^INFO $EXPECTED_ABS_PATHS_PREFIX:.*should print" >/dev/null
 }
 
 t_no_output_if_DEBUG_not_set() {
@@ -551,6 +565,20 @@ t_prefix_when_run_in_subshell() {
         (
             [[ $(DEBUG=true FROM_STACKFRAME=0 set_log_prefix) == "$expected" ]]
         )
+    )
+}
+
+t_prefix_debug_abs_paths_set() {
+    local expected="$EXPECTED_ABS_PATHS_PREFIX:t_prefix_debug_abs_paths_set()"
+    (
+        [[ $(DEBUG=true DEBUG_ABS_PATHS=true FROM_STACKFRAME=0 set_log_prefix) == "$expected" ]]
+    )
+}
+
+t_prefix_no_debug_with_abs_paths() {
+    local expected="$EXPECTED_ABS_PATHS_PREFIX:t_prefix_debug_with_abs_paths()"
+    (
+        [[ $(DEBUG_ABS_PATHS=true FROM_STACKFRAME=0 set_log_prefix) == "$expected" ]]
     )
 }
 


### PR DESCRIPTION
Previously, debug output would use /abs/path/to/source/file in message prefix.
Now it defaults to filename alone, but user can set DEBUG_ABS_PATHS to print
abs paths to src files independent of DEBUG setting. e.g.
    `DEBUG_ABS_PATHS=true i "... boo" # prefix to msg uses abs path to source`
* ✔ fixed awk warning when generating docs
* ✔ tests added for DEBUG_ABS_PATHS
* ✔ docs updated