### PR TITLE
std::render_tmpl function; ci and tests bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 **/release-artefacts
+**/*.swp
+**/*.swo

--- a/bash/bundles/release
+++ b/bash/bundles/release
@@ -13,7 +13,7 @@ release() {
 
     rm -rf $RELEASE_DIR 2>/dev/null
 
-    if [[ "$IS_GIT_TAG" == "true" ]] || [[ "$IS_RELEASE" == "true" ]]; then
+    if [[ "$IS_GIT_TAG" == "true" ]] ; then
 
         echo "shippable vars:"
         echo "BRANCH: $BRANCH"

--- a/bash/habitual/std.functions
+++ b/bash/habitual/std.functions
@@ -128,6 +128,78 @@ std::trim_str() {
     echo -n "$v"
 }
 
+# @desc Replaces bash vars (and optionally executes bash code) in a template file.
+#
+# An empty var value will render as nothing in the tmpl.
+# You can literal dollars with a backslash.
+#
+# The path to the template file can be passed as an argument,
+# or set as the value to $file_tmpl before calling the function.
+#
+# By default, any $() or backticks in the tmpl will be escaped
+# unless already preceded with backslash. Multiple backslashes before a $( or backtick
+# are collapsed to a single backslash. No sneaky executing bash that way I'm afraid.
+#
+# If you really want to let code execute in the tmpl when you call this function,
+# pass "true" as 2nd param, or set allow_code=true before calling function.
+# But remember that if you are not in control of template content, this is a security
+# risk - $(rm -rf *.* anyone???)
+#
+# > *IMPORTANT - MULTIPLE TRAILING NEWLINES IN TMPL:*
+# > If these must be preserved, don't use this function.
+# > In fact, reconsider using bash at all.
+# > There are many contexts where bash will swallow trailing newlines
+# > e.g. when reading with command expansion, subshells, inline file handles
+#
+# @example
+#   # /path/to/tmpl contains: I eat $number ${fruit}s.
+#   
+#   fruit=apple number=2 std::render_tmpl "/path/to/tmpl"
+#   # ^^^ outputs "I eat 2 apples"
+#   
+#   file_tmpl="/path/to/tmpl"
+#   fruit=banana number=3 std::render_tmpl # no param needed as file_tmpl set
+#   # ^^^ outputs "I eat 3 bananas"
+#   
+#   # allow code to execute.
+#   # /path/to/tmpl2 contains : I say $(echo Howdy Pardner!!! )
+#   allow_code=true std::render_tmpl "/path/to/tmpl2"
+#   # ^^^ outputs "I say Howdy Pardner!!! "
+#
+std::render_tmpl() {
+    local file_tmpl="${1:-$file_tmpl}"
+    local allow_code="${2:-$allow_code}" # default is to not execute code on render.
+    required_vars "file_tmpl" || return 1
+    [[ ! -r "$file_tmpl" ]] && e "$file_tmpl is not readable" && return 1
+
+    local d="" delim="__render_tmpl__" cmd=""
+
+    d=$(< "$file_tmpl")
+
+    if [[ ! "$allow_code" =~ ^(allow|true|y|yes|1)$ ]]; then
+        d="$(_stop_breakouts_in_render "$d")"
+    fi
+
+    cmd="cat <<$delim"$'\n'"$d"$'\n'"$delim" # creates a heredoc
+    eval "$cmd"
+
+    # ... check eval worked syntactically ...
+    [[ $? -ne 0 ]] && e "... failed to render file $file_tmpl" && return 1
+
+    return 0
+}
+
+_stop_breakouts_in_render() {
+    local d="$1"
+    echo "$d" \
+    | sed \
+        -e 's/\([^\\]\)`/\1\\`/g' `# catch backticks preceded by non-backslash` \
+        -e 's/^`/\\`/g' `# catch backticks at start of line` \
+        -e 's/\([^\\]\)\$(/\1\\\$(/g' `# $( preceded by non-backslash` \
+        -e 's/^\$(/\\\$(/g' `# $( at start of line` \
+        -e 's/\\\+\([`\$]\)/\\\1/g' `# reduce n backslashes to 1 before $( or backtick`
+}
+
 # @desc Prints a user-passed *single-line* str with all instances of certain chars
 # replaced by a safe character.
 #

--- a/bash/habitual/std.functions.md
+++ b/bash/habitual/std.functions.md
@@ -37,6 +37,7 @@
 * [required\_vars()](#required_vars)
 * [check\_var\_defined()](#check_var_defined)
 * [std::trim\_str()](#stdtrim_str)
+* [std::render\_tmpl()](#stdrender_tmpl)
 * [str\_to\_safe\_chars()](#str_to_safe_chars)
 * [safe\_chars\_def\_list()](#safe_chars_def_list)
 * [envsubst\_tokens\_list()](#envsubst_tokens_list)
@@ -156,6 +157,53 @@ Trim leading and trailing whitespace from a string
 ```bash
 std::trim_str " <- spaces disappear! ->  "
 # ^^^ outputs "<- spaces disappear! ->"
+
+```
+
+
+---
+
+### std::render\_tmpl()
+
+Replaces bash vars (and optionally executes bash code) in a template file.
+
+An empty var value will render as nothing in the tmpl.
+You can literal dollars with a backslash.
+
+The path to the template file can be passed as an argument,
+or set as the value to $file_tmpl before calling the function.
+
+By default, any $() or backticks in the tmpl will be escaped
+unless already preceded with backslash. Multiple backslashes before a $( or backtick
+are collapsed to a single backslash. No sneaky executing bash that way I'm afraid.
+
+If you really want to let code execute in the tmpl when you call this function,
+pass "true" as 2nd param, or set allow_code=true before calling function.
+But remember that if you are not in control of template content, this is a security
+risk - $(rm -rf *.* anyone???)
+
+> *IMPORTANT - MULTIPLE TRAILING NEWLINES IN TMPL:*
+> If these must be preserved, don't use this function.
+> In fact, reconsider using bash at all.
+> There are many contexts where bash will swallow trailing newlines
+> e.g. when reading with command expansion, subshells, inline file handles
+
+#### Example
+
+```bash
+# /path/to/tmpl contains: I eat $number ${fruit}s.
+
+fruit=apple number=2 std::render_tmpl "/path/to/tmpl"
+# ^^^ outputs "I eat 2 apples"
+
+file_tmpl="/path/to/tmpl"
+fruit=banana number=3 std::render_tmpl # no param needed as file_tmpl set
+# ^^^ outputs "I eat 3 bananas"
+
+# allow code to execute.
+# /path/to/tmpl2 contains : I say $(echo Howdy Pardner!!! )
+allow_code=true std::render_tmpl "/path/to/tmpl2"
+# ^^^ outputs "I say Howdy Pardner!!! "
 
 ```
 

--- a/bash/t/habitual/fixtures/breakout.tmpl
+++ b/bash/t/habitual/fixtures/breakout.tmpl
@@ -1,0 +1,10 @@
+Let's embed some bash inline.
+$(echo "Break Out!!! sudo rm -rf /* anyone?")
+
+Or anything in the env ...
+$(export SUPER_SECRET=wibble ; export | grep SUPER_SECRET)
+
+Or backticks ...
+`echo this is from backticks`
+
+A man could do a lot of damage with the wrong template ...

--- a/bash/t/habitual/fixtures/breakout_allowed.result
+++ b/bash/t/habitual/fixtures/breakout_allowed.result
@@ -1,0 +1,10 @@
+Let's embed some bash inline.
+Break Out!!! sudo rm -rf /* anyone?
+
+Or anything in the env ...
+declare -x SUPER_SECRET="wibble"
+
+Or backticks ...
+this is from backticks
+
+A man could do a lot of damage with the wrong template ...

--- a/bash/t/habitual/fixtures/breakout_not_allowed.result
+++ b/bash/t/habitual/fixtures/breakout_not_allowed.result
@@ -1,0 +1,10 @@
+Let's embed some bash inline.
+$(echo "Break Out!!! sudo rm -rf /* anyone?")
+
+Or anything in the env ...
+$(export SUPER_SECRET=wibble ; export | grep SUPER_SECRET)
+
+Or backticks ...
+`echo this is from backticks`
+
+A man could do a lot of damage with the wrong template ...

--- a/bash/t/habitual/fixtures/escaped_vars.result
+++ b/bash/t/habitual/fixtures/escaped_vars.result
@@ -1,0 +1,3 @@
+Say hello to Dollar Var.
+Or as we call him $var.
+Or even ${var}.

--- a/bash/t/habitual/fixtures/escaped_vars.tmpl
+++ b/bash/t/habitual/fixtures/escaped_vars.tmpl
@@ -1,0 +1,3 @@
+Say hello to Dollar Var.
+Or as we call him \$var.
+Or even \${var}.

--- a/bash/t/habitual/fixtures/multiline.result
+++ b/bash/t/habitual/fixtures/multiline.result
@@ -1,0 +1,4 @@
+Say hello to Foo Bar.
+Now say goodbye to Foo.
+
+Bye Mr/Mrs/Ms. Bar.

--- a/bash/t/habitual/fixtures/multiline.tmpl
+++ b/bash/t/habitual/fixtures/multiline.tmpl
@@ -1,0 +1,4 @@
+Say hello to $prenombre $apellido.
+Now say goodbye to $prenombre.
+
+Bye Mr/Mrs/Ms. $apellido.

--- a/bash/t/habitual/fixtures/multiple_backslashes_for_breakouts.tmpl
+++ b/bash/t/habitual/fixtures/multiple_backslashes_for_breakouts.tmpl
@@ -1,0 +1,7 @@
+cmd substitution subshell:
+inline: \$(echo "from backslashed subshell in middle of line")
+\\$(echo "from backslashed subshell at beginning of line")
+
+`echo unescaped backticks at beginning of line`
+
+\\\\`echo backticks already escaped\\`

--- a/bash/t/habitual/fixtures/singleline.tmpl
+++ b/bash/t/habitual/fixtures/singleline.tmpl
@@ -1,0 +1,1 @@
+I eat $number ${fruit}s.

--- a/bash/t/habitual/fixtures/some_backslashed_breakouts.result
+++ b/bash/t/habitual/fixtures/some_backslashed_breakouts.result
@@ -1,0 +1,7 @@
+cmd substitution subshell:
+inline: $(echo "from backslashed subshell in middle of line")
+$(echo "from backslashed subshell at beginning of line")
+
+`echo unescaped backticks at beginning of line`
+
+`echo backticks already escaped`

--- a/bash/t/habitual/fixtures/some_backslashed_breakouts.tmpl
+++ b/bash/t/habitual/fixtures/some_backslashed_breakouts.tmpl
@@ -1,0 +1,7 @@
+cmd substitution subshell:
+inline: \$(echo "from backslashed subshell in middle of line")
+\$(echo "from backslashed subshell at beginning of line")
+
+`echo unescaped backticks at beginning of line`
+
+\`echo backticks already escaped\`

--- a/bash/t/habitual/fixtures/var_not_defined.result
+++ b/bash/t/habitual/fixtures/var_not_defined.result
@@ -1,0 +1,4 @@
+Say hello to  Bar.
+Now say goodbye to .
+
+Bye Mr/Mrs/Ms. Bar.

--- a/bash/t/habitual/std.functions
+++ b/bash/t/habitual/std.functions
@@ -14,6 +14,13 @@ STR_UTF8_COPYRIGHT="$INPUT_STR_ASCII$(printf '\xC2\xA9')"
 STR_UTF8_FLAT_E="cafe attache mate trema"
 UTF8_ACUTE_E="$(printf '\xC3\xA9')" # e with acute accent
 
+
+FIXTURES="$(dirname $BASH_SOURCE)/fixtures"
+SL_TMPL="$FIXTURES/singleline.tmpl"
+ML_TMPL="$FIXTURES/multiline.tmpl"
+EXPECTED_ML_RESULT="$FIXTURES/multiline.result"
+
+
 run_safe_chars_posix() {
     local loc=POSIX
     ( loc="$loc" _run_safe_chars "$1" "$2" "$3" ) || return 1
@@ -79,6 +86,122 @@ t_std::trim_str() {
     run_t t_no_whitespace_unchanged
     run_t t_whitespace_tabs
     run_t t_whitespace_newlines
+}
+
+### std::render_tmpl()
+t_std::render_tmpl() {
+    SUITE="${FUNCNAME[0]#t_}()"
+    run_t t_render_file_tmpl_not_given
+    run_t t_render_line_simple
+    run_t t_render_with_file_tmpl_as_var
+    run_t t_render_prefer_param_to_var
+    run_t t_render_file_unreadable
+    run_t t_render_multiline_tmpl
+    run_t t_render_var_defined_empty
+    run_t t_render_var_not_defined
+    run_t t_render_escaped_vars
+    run_t t_render_code_not_executed_by_default
+    run_t t_render_escape_breakouts_unless_already_escaped
+    run_t t_render_multiple_backslashes_code_not_executed
+}
+
+t_render_multiple_backslashes_code_not_executed() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$FIXTURES/multiple_backslashes_for_breakouts.tmpl"
+    local var="should not be used"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/some_backslashed_breakouts.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_escape_breakouts_unless_already_escaped() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$FIXTURES/some_backslashed_breakouts.tmpl"
+    local var="should not be used"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/some_backslashed_breakouts.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_code_is_executed() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$FIXTURES/breakout.tmpl"
+    local allow_code="true"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/breakout_allowed.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_code_not_executed_by_default() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$FIXTURES/breakout.tmpl"
+    local var="should not be used"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/breakout_not_allowed.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_escaped_vars() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$FIXTURES/escaped_vars.tmpl"
+    local var="should not be used"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/escaped_vars.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_file_tmpl_not_given() {
+    std::render_tmpl 2>&1 \
+    | grep -q 'required_vars().* \$file_tmpl'
+}
+
+t_render_var_not_defined() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$ML_TMPL" apellido="Bar"
+    std::render_tmpl >$f || return 1
+    diff $f $FIXTURES/var_not_defined.result
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_var_defined_empty() {
+    local f=$(mktemp) f2=$(mktemp)
+    local rc=0
+    echo '$fruit' > $f
+    ( fruit="" std::render_tmpl "$f" > $f2 )
+
+    diff $f2 <(echo ""); rc=$? ; rm $f $f2 ; return $rc
+
+}
+
+t_render_multiline_tmpl() {
+    local f=$(mktemp) ; local rc=0
+    local file_tmpl="$ML_TMPL" prenombre="Foo" apellido="Bar"
+    std::render_tmpl >$f || return 1
+    diff $f $EXPECTED_ML_RESULT
+    rc=$? ; rm $f ; return $rc
+}
+
+t_render_line_simple() {
+    local number=2 fruit="apple"
+    [[ "$(std::render_tmpl $SL_TMPL)" == "I eat 2 apples." ]]
+}
+
+t_render_with_file_tmpl_as_var() {
+    local file_tmpl="$SL_TMPL" number=2 fruit="apple"
+    [[ "$(std::render_tmpl)" == "I eat 2 apples." ]]
+}
+
+t_render_prefer_param_to_var() {
+    local file_tmpl="/path/not/exist" number=2 fruit="apple"
+    [[ "$(std::render_tmpl "$SL_TMPL")" == "I eat 2 apples." ]]
+}
+
+t_render_file_unreadable() {
+    local f=$(mktemp) ; local rc=0
+    ! cp $SL_TMPL $f && echo >&2 "ERROR: could not copy template to $f" && return 1
+    ! chmod 0333 $f && echo >&2 "ERROR: could not change file mode" && return 1
+    std::render_tmpl "$f" 2>&1 | grep -q "$f is not readable"
+    rc=$? ; rm -f $f ; return $rc
 }
 
 t_leading_whitespace_removed() {

--- a/bash/t/t.functions
+++ b/bash/t/t.functions
@@ -62,7 +62,7 @@ run_t() {
 
 funcs_to_test() {
     local src="$1"
-    grep -Po '^(function +)?[\w_]+ *\(\) *{ *$' $src | sed -e 's/\([^ (]\+\).*/\1/'
+    grep -Po '^(function +)?[\w:_]+ *\(\) *{ *$' $src | sed -e 's/\([^ (]\+\).*/\1/'
 }
 
 source_src_and_deps() {

--- a/shippable.build.sh
+++ b/shippable.build.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# vim: et sr sw=4 ts=4 smartindent:
+
+CIUSER_HOME=/home/ciuser
+CIUSER_BUILD_DIR=$CIUSER_HOME/build
+NVM_DIR=$CIUSER_HOME/.nvm
+
+install_tools() {
+    sudo apt-get update
+    sudo apt-get install -y coreutils realpath
+    sort --help | grep -q -- '--version-sort' || return 1 # ...verify coreutils
+    realpath $PWD >/dev/null || return 1                  # ... verify realpath
+}
+
+# workarounds because of quirky behaviour when building
+# on shippable nodes.
+shippable_hacks() {
+    hack_nvm_sh  || return 1
+}
+
+# hack_nvm_sh() :
+# Required to suppress spurious error on standard shippable build node
+# when running with non-root user.
+# The standard shippable build node will call nvm.sh
+# any time a user shell is invoked, but only root has nvm.sh available.
+hack_nvm_sh() {
+    mkdir $NVM_DIR 2>/dev/null
+    echo '#!/bin/bash' > $NVM_DIR/nvm.sh
+    chmod a+x $NVM_DIR/nvm.sh
+    chown -R ciuser:ciuser $NVM_DIR
+}
+
+prepare_ciuser() {
+    adduser --disabled-password --gecos "" ciuser || return 1
+    cp -r $SHIPPABLE_BUILD_DIR $CIUSER_BUILD_DIR || return 1
+    chown -R ciuser:ciuser $CIUSER_BUILD_DIR || return 1
+}
+
+prepare_env() {
+    install_tools   || return 1
+    prepare_ciuser || return 1
+    shippable_hacks || return 1
+}
+
+build() { return 0 ; } # nothing to build yet
+
+main() {
+    prepare_env || return 1
+    build || return 1
+}
+
+main

--- a/shippable.test.sh
+++ b/shippable.test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# vim: et sr sw=4 ts=4 smartindent:
+CIUSER_HOME=/home/ciuser
+CIUSER_BUILD_DIR=$CIUSER_HOME/build
+BASH_LIBS_DIR=$CIUSER_BUILD_DIR/bash
+
+find_libs_to_test() {
+    find . -path './t' -prune -o -name '*.functions' -print
+}
+
+run_bash_test_file() {
+    local lib="$1"
+    local f="t/${lib#./}"
+
+    [[ ! -x $f ]] && echo "INFO: no tests for $lib in $f" && return 0
+
+    echo -e "\n\nINFO: RUNNING $f as $CIUSER in $BASH_LIBS_DIR ..."
+    su -c "cd $BASH_LIBS_DIR && $f" ciuser && return 0
+
+    echo >&2 "ERROR: failure from $lib"
+    return 1
+}
+
+run_bash_tests() {
+    local rc=0
+    for lib in $(find_libs_to_test); do
+        run_bash_test_file "$lib" || rc=1
+    done
+    return $rc
+}
+
+main() {
+    echo "INFO: running tests for bash libs"
+    ( cd $BASH_LIBS_DIR && run_bash_tests )
+}
+
+main

--- a/shippable.yml
+++ b/shippable.yml
@@ -10,18 +10,7 @@ env:
 build:
 
   ci:
-    - sudo apt-get update && sudo apt-get install -y coreutils realpath ;
-      (
-        cd bash ;
-        echo "running tests for bash libs" ;
-        rc=0 ; libs="$(find . -path './t' -prune -o -name '*.functions' -print)" ;
-        for lib in $libs; do
-          f="t/${lib#./}" ;
-          echo -e "\n\nRUNNING $f ..." ;
-          [[ -x $f ]] && ! $f && echo "failure from $lib" && rc=1 ;
-        done ;
-        [[ $rc -eq 0 ]]
-      )
+    - chmod a+x shippable.*.sh ; ( ./shippable.build.sh && ./shippable.test.sh )
 
   on_success: ./bash/bundles/release
 


### PR DESCRIPTION
* new function: habitual std::render_tmpl
* CI will only build release bundle on a tag push
* tests now actually run for functions with colons in the name 